### PR TITLE
Feature/steam auth support

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -13,6 +13,9 @@ services:
       - "21025:21025/udp"
     volumes:
       - /path/to/volume:/opt/starbound
+    secrets:
+      - steam_username
+      - steam_password      
     environment:
       - PUID=4711
       - PGID=4711
@@ -25,3 +28,9 @@ services:
       # - SERVER_MAP_ID=0
       # - SERVER_WORLD_SIZE=5
       # - SERVER_SLOT_COUNT=10
+
+secrets:
+  steam_username:
+    file: /path/to/secrets/steam_username.txt
+  steam_password:
+    file: /path/to/secrets/steam_password.txt      

--- a/scripts/default/starbound-updater
+++ b/scripts/default/starbound-updater
@@ -12,12 +12,31 @@ main() {
 downloadStarbound() {
   debug "Downloading Starbound server"
 
+  # Read Docker secrets (mounted at /run/secrets/ -- create this file and define location in docker-compose)
+  if [ -f /run/secrets/steam_username ]; then
+    STEAM_USERNAME=$(cat /run/secrets/steam_username)
+  else
+    error "Missing secret: steam_username"
+    exit 1
+  fi
+
+  if [ -f /run/secrets/steam_password ]; then
+    STEAM_PASSWORD=$(cat /run/secrets/steam_password)
+  else
+    error "Missing secret: steam_password"
+    exit 1
+  fi
+
   mkdir -p "$install_path/steamapps/compatdata/$steam_app_id"
   export STEAM_COMPAT_CLIENT_INSTALL_PATH="/home/starbound/.steam/steam"
   export STEAM_COMPAT_DATA_PATH="$install_path/steamapps/compatdata/$steam_app_id"
   export STEAM_DIR="/home/starbound/.steam/steam/"
 
-  $steamcmd_path +force_install_dir "$install_path" +login anonymous +app_update $steam_app_id "$GAME_BRANCH $STEAMCMD_ARGS" +quit
+  # Authenticated Steam login
+  $steamcmd_path +force_install_dir "$install_path" \
+                 +login "$STEAM_USERNAME" "$STEAM_PASSWORD" \
+                 +app_update $steam_app_id "$GAME_BRANCH $STEAMCMD_ARGS" \
+                 +quit
 }
 
 checkForUpdates() {


### PR DESCRIPTION
- Expand 'docker-compose' to include Docker-native 'secrets' component (https://docs.docker.com/compose/how-tos/use-secrets/)
- Add authenticated login to Steam (as Starbound does not support anonymous logins nor token-based auth)
- Add logic to check for presence and content of 'steam_username' and 'steam_password' secrets