### PR TITLE
Fix/starbound server launch

### DIFF
--- a/scripts/default/common
+++ b/scripts/default/common
@@ -1,9 +1,9 @@
 #!/bin/bash
-install_path=/opt/starbound/linux
+install_path=/opt/starbound/
 version_file_path=/opt/starbound/current_version
 steamcmd_path=/usr/bin/steamcmd
 steam_app_id=211820
-starbound_binary_path=starbound_server
+starbound_binary_path=/linux/starbound_server
 savefile_name=3ad85aea # TODO: Target the Starbound "universe" file in 'savefile_name'
 # plainsofpain_world_sizes="3 5 7 9 11"
 

--- a/scripts/default/starbound-server
+++ b/scripts/default/starbound-server
@@ -33,8 +33,8 @@ runServer() {
   export STEAM_COMPAT_DATA_PATH="$install_path/steamapps/compatdata/$steam_app_id"
 
   chmod +x "$starbound_server"
-  $starbound_server -nographics -batchmode -localhost -startServer -ignorecompilererrors -overrideTerrainData -config "${install_path}/starbound_server.json" &
-  starbound_server_pid=$! #TODO: Determine if there are any startup args to pass to Starbound server; determine if 'starbound_server.json' needs to be 'starbound_server.config'
+  $starbound_server -config "${install_path}/starbound_server.json" & # TODO: Invoke 'sbinit.config' here (via '-bootConfig')
+  starbound_server_pid=$! #TODO: Determine if there are any startup args to pass to Starbound server; determine if 'starbound_server.json' needs to be 'starbound_server.config' or 'sbinit.config'
   echo $starbound_server_pid >"$starbound_server_pidfile"
 
   wait $starbound_server_pid

--- a/scripts/default/starbound-updater
+++ b/scripts/default/starbound-updater
@@ -12,7 +12,10 @@ main() {
 downloadStarbound() {
   debug "Downloading Starbound server"
 
-  # Read Docker secrets (mounted at /run/secrets/ -- create this file and define location in docker-compose)
+  echo "Checking for Docker secrets in /run/secrets"
+  ls -l /run/secrets || echo "[DEBUG] /run/secrets does not exist"
+
+  # Read Docker secrets (mounted at /run/secrets/)
   if [ -f /run/secrets/steam_username ]; then
     STEAM_USERNAME=$(cat /run/secrets/steam_username)
   else
@@ -32,7 +35,7 @@ downloadStarbound() {
   export STEAM_COMPAT_DATA_PATH="$install_path/steamapps/compatdata/$steam_app_id"
   export STEAM_DIR="/home/starbound/.steam/steam/"
 
-  # Authenticated Steam login
+  # Steam login and update
   $steamcmd_path +force_install_dir "$install_path" \
                  +login "$STEAM_USERNAME" "$STEAM_PASSWORD" \
                  +app_update $steam_app_id "$GAME_BRANCH $STEAMCMD_ARGS" \


### PR DESCRIPTION
- Remove extraneous server-launch arguments (fixes pre-check process halt due to "too many arguments")
- Modify install path so that data is actually stored in the root of the designated volume (as intended)
- Modify the server binary path so that subsequent scripts can actually find it (scripts failed to proceed previously)