### PR TITLE
feature/install openstarbound

### DIFF
--- a/scripts/default/common
+++ b/scripts/default/common
@@ -7,6 +7,8 @@ starbound_binary_path=linux/starbound_server
 savefile_name=3ad85aea # TODO: Target the Starbound "universe" file in 'savefile_name'
 openstarbound_staging_path=/tmp/openstarbound/staging
 openstarbound_download_path=/tmp/openstarbound/download
+openstarbound_version_file_path=/opt/openstarbound/version
+openstarbound_github_api=https://api.github.com/repos/OpenStarbound/OpenStarbound/releases/latest
 # plainsofpain_world_sizes="3 5 7 9 11"
 
 # trap SIGUSR1 as it is being used to check

--- a/scripts/default/defaults
+++ b/scripts/default/defaults
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Server Settings
+USE_OPENSTARBOUND=${USE_OPENSTARBOUND:-false}
 SERVER_NAME=${SERVER_NAME} # defaults to Plains of Pain Server
 SERVER_PASSWORD=${SERVER_PASSWORD}
 SERVER_SEED=${SERVER_SEED} # defaults to 40337

--- a/scripts/default/openstarbound-updater
+++ b/scripts/default/openstarbound-updater
@@ -1,0 +1,106 @@
+#!/bin/bash
+. "$(dirname "$0")/common"
+. "$(dirname "$0")/defaults"
+. "$(dirname "$0")/openstarbound-updater-shared"
+
+main() {
+  info "Running openstarbound-updater"
+  updateOpenStarbound
+  info "openstarbound-updater complete"
+}
+
+downloadOpenStarbound() {
+  info "Downloading OpenStarbound version $openstarbound_latest_version"
+
+  # Create OpenStarbound download directory
+  mkdir -p "$openstarbound_download_path"
+
+  # Create OpenStarbound staging directory
+  mkdir -p "$openstarbound_staging_path"
+  
+  # Get download URL for the OpenStarbound Linux Server asset
+  local openstarbound_download_url
+  openstarbound_download_url=$(curl -sX GET "$openstarbound_github_api" | jq -r '.assets[] | select((.name | test("linux"; "i")) and (.name | test("server"; "i"))) | .browser_download_url')
+
+  if [ -z "$openstarbound_download_url" ] || [ "$openstarbound_download_url" == "null" ]; then
+    error "Failed to get download URL for OpenStarbound Linux Server"
+    return 1
+  fi
+  
+  # Download OpenStarbound Linux Server asset and extract
+  local openstarbound_archive_path="$openstarbound_download_path/OpenStarbound-Linux-Server.zip"
+  curl -sL "$openstarbound_download_url" -o "$openstarbound_archive_path"
+  
+  if [ ! -f "$openstarbound_archive_path" ]; then
+    error "Failed to download OpenStarbound Linux Server asset"
+    return 1
+  fi
+  
+  # Extract the downloaded OpenStarbound Linux Server asset
+  info "Extracting OpenStarbound Linux Server asset..."
+  tar -xzf "$openstarbound_archive_path" -C "$openstarbound_staging_path"
+
+  # Remove the recently downloaded OpenStarbound Linux Server asset
+  info "Cleaning up OpenStarbound download directory..."
+  find "$openstarbound_download_path" -type f \( -iname '*linux*' -iname '*server*' \) -exec rm -f {} +
+
+  info "OpenStarbound downloaded to staging directory"
+  return 0
+}
+
+installOpenStarbound() {
+  info "Installing OpenStarbound Linux Server version $openstarbound_latest_version ..."
+  
+  # Check if the required OpenStarbound files exist
+  if [ ! -f "$openstarbound_staging_path/server_distribution/linux/btree_repacker" ] || \
+     [ ! -f "$openstarbound_staging_path/server_distribution/linux/starbound_server" ] || \
+     [ ! -f "$openstarbound_staging_path/server_distribution/assets/opensb.pak" ]; then
+    error "OpenStarbound files are missing in staging directory"
+    return 1
+  fi
+  
+  # Copy required OpenStarbound files to the Starbound installation path
+  cp -f "$openstarbound_staging_path/server_distribution/linux/btree_repacker" "$install_path/linux/"
+  cp -f "$openstarbound_staging_path/server_distribution/linux/starbound_server" "$install_path/linux/"
+  cp -f "$openstarbound_staging_path/server_distribution/assets/opensb.pak" "$install_path/assets/"
+  
+  # Make binaries executable
+  chmod +x "$install_path/linux/btree_repacker"
+  chmod +x "$install_path/linux/starbound_server"
+  
+  # Update version file
+  setOpenStarboundCurrentVersion
+  
+  info "OpenStarbound Linux Server version $openstarbound_latest_version installed successfully"
+  return 0
+}
+
+updateOpenStarbound() {
+  if [ "$USE_OPENSTARBOUND" != "true" ]; then
+    debug "OpenStarbound is disabled, skipping update"
+    return 0
+  fi
+  
+  info "Updating OpenStarbound Linux Server..."
+  
+  # First check if an OpenStarbound update is available
+  if ! checkForOpenStarboundUpdates; then
+    debug "No OpenStarbound Linux Server update needed"
+    return 0
+  fi
+  
+  if fetchOpenStarbound; then
+    if installOpenStarbound; then
+      info "OpenStarbound Linux Server update completed successfully"
+      return 0
+    else
+      error "Failed to install OpenStarbound Linux Server"
+      return 1
+    fi
+  else
+    error "Failed to download OpenStarbound Linux Server"
+    return 1
+  fi
+}
+
+main

--- a/scripts/default/openstarbound-updater
+++ b/scripts/default/openstarbound-updater
@@ -89,7 +89,7 @@ updateOpenStarbound() {
     return 0
   fi
   
-  if fetchOpenStarbound; then
+  if downloadOpenStarbound; then
     if installOpenStarbound; then
       info "OpenStarbound Linux Server update completed successfully"
       return 0

--- a/scripts/default/openstarbound-updater-shared
+++ b/scripts/default/openstarbound-updater-shared
@@ -1,0 +1,52 @@
+#!/bin/bash
+. "$(dirname "$0")/common"
+. "$(dirname "$0")/defaults"
+
+openstarbound_latest_version=-1
+
+checkForOpenStarboundUpdates() {
+  if [ "$USE_OPENSTARBOUND" != "true" ]; then
+    debug "OpenStarbound is disabled, skipping check"
+    return 1
+  fi
+
+  local openstarbound_current_version
+
+  if [ -f "$openstarbound_version_file_path" ]; then
+    openstarbound_current_version=$(cat "$openstarbound_version_file_path")
+    debug "Current OpenStarbound version: $openstarbound_current_version"
+  else
+    openstarbound_current_version="0"
+    debug "No OpenStarbound version file found, setting current version to 0"
+  fi
+
+  # Get latest version from GitHub API (tag_name without leading 'v')
+  openstarbound_latest_version=$(curl -sX GET "$openstarbound_github_api" | jq -r '.tag_name' | sed 's/^v//')
+
+  if [ "$openstarbound_latest_version" == "null" ] || [ -z "$openstarbound_latest_version" ]; then
+    if [ "$openstarbound_current_version" == "0" ]; then
+      warn "Unable to determine latest version of OpenStarbound! No version currently installed, will attempt installation"
+      return 0
+    fi
+    warn "Unable to determine latest version of OpenStarbound! No update will be performed"
+    return 1
+  fi
+
+  debug "Latest OpenStarbound version: $openstarbound_latest_version"
+  if [ "$openstarbound_current_version" != "$openstarbound_latest_version" ]; then
+    info "OpenStarbound needs to be updated from $openstarbound_current_version to $openstarbound_latest_version"
+    return 0
+  else
+    info "OpenStarbound is already the latest version ($openstarbound_latest_version)"
+    return 1
+  fi
+}
+
+setOpenStarboundCurrentVersion() {
+  if [ "$openstarbound_latest_version" == "null" ] || [ -z "$openstarbound_latest_version" ]; then
+    warn "Unable to set current OpenStarbound version - latest version is unknown"
+    return 1
+  fi
+  debug "[setOpenStarboundCurrentVersion]: $openstarbound_latest_version"
+  echo "$openstarbound_latest_version" > "$openstarbound_version_file_path"
+}

--- a/scripts/default/starbound-updater-shared
+++ b/scripts/default/starbound-updater-shared
@@ -18,7 +18,17 @@ update() {
   trap shutdown SIGINT SIGTERM
 
   # Check for Starbound updates
-  if ! checkForUpdates; then
+  if checkForUpdates; then
+    starbound_update_needed=true
+  fi
+  
+  # Check for OpenStarbound updates if enabled
+  if [ "$USE_OPENSTARBOUND" == "true" ] && checkForOpenStarboundUpdates; then
+    openstarbound_update_needed=true
+  fi
+  
+  # If no updates needed, exit
+  if [ "$starbound_update_needed" == "false" ] && [ "$openstarbound_update_needed" == "false" ]; then
     if ! checkRunning "starbound-server"; then
       info "Starbound server is not running - starting"
       supervisorctl start starbound-server
@@ -32,7 +42,8 @@ update() {
     return
   fi
 
-  doUpdate &
+# Start update process
+  doUpdate "$starbound_update_needed" "$openstarbound_update_needed" &
   starbound_updater_pid=$!
   echo $starbound_updater_pid >"$pidfile"
   wait $starbound_updater_pid

--- a/scripts/default/starbound-updater-shared
+++ b/scripts/default/starbound-updater-shared
@@ -1,16 +1,23 @@
 #!/bin/bash
 . "$(dirname "$0")/common"
 . "$(dirname "$0")/defaults"
+. "$(dirname "$0")/openstarbound-updater-shared"
 
 pidfile=$starbound_updater_pidfile
 latest_version=-1
 
 update() {
+  local starbound_update_needed=false
+  local openstarbound_update_needed=false
+
+  # PID lock check
   if [ -f "$pidfile" ]; then
     info "Found existing PID file - checking process"
     checkLock $pidfile
   fi
   trap shutdown SIGINT SIGTERM
+
+  # Check for Starbound updates
   if ! checkForUpdates; then
     if ! checkRunning "starbound-server"; then
       info "Starbound server is not running - starting"
@@ -18,6 +25,8 @@ update() {
     fi
     return
   fi
+
+  # Check if the server is empty
   if ! checkServerEmpty; then
     warn "Starbound server is not empty - update will not be performed"
     return

--- a/scripts/default/starbound-updater-shared
+++ b/scripts/default/starbound-updater-shared
@@ -1,6 +1,7 @@
 #!/bin/bash
 . "$(dirname "$0")/common"
 . "$(dirname "$0")/defaults"
+. "$(dirname "$0")/openstarbound-updater"
 . "$(dirname "$0")/openstarbound-updater-shared"
 
 pidfile=$starbound_updater_pidfile
@@ -50,18 +51,39 @@ update() {
 }
 
 doUpdate() {
+  local starbound_update_needed=$1
+  local openstarbound_update_needed=$2
+
   updatePreHook
+  
+  # Check if the server is running and stop it
   if checkRunning "starbound-server"; then
     supervisorctl stop starbound-server
   fi
-  verifyCpuMhz
-  if ! downloadStarbound; then
-    warn "Download of Starbound server failed - aborting update"
-    supervisorctl start starbound-server
-    clearLock "$pidfile"
-    return
+
+  # Update Starbound if needed
+  if [ "$starbound_update_needed" == "true" ]; then
+    info "Updating Starbound..."
+    verifyCpuMhz
+    if ! downloadStarbound; then
+      warn "Download of Starbound server failed - aborting..."
+      supervisorctl start starbound-server
+      clearLock "$pidfile"
+      return
+    fi
+    setCurrentVersion
   fi
-  setCurrentVersion
+
+  # Update OpenStarbound if needed
+  if [ "$openstarbound_update_needed" == "true" ] && [ "$USE_OPENSTARBOUND" == "true" ]; then
+    if ! updateOpenStarbound; then
+      warn "OpenStarbound update failed - aborting..."
+      clearLock "$pidfile"
+      return
+    fi
+  fi
+
+  # Restart the server and run post-update hooks
   supervisorctl start starbound-server
   updatePostHook
 


### PR DESCRIPTION
Introduce secondary functions to download and install OpenStarbound - if enabled via dedicated env var (`USE_STARBOUND`, true, false). This mechanism includes version checking, utilization of existing process-lock/PID-check mechanisms, server-state checks (server empty? server offline? server updating? etc.), cron-based scheduling, and overall process handling from supervisord.

Largely based on core concept from @mornedhels (specifically @cp-fabian-pittroff) from their 'enshrouded-server' implementation pattern.