### PR TITLE
debug/osb order of operations

### DIFF
--- a/scripts/default/openstarbound-updater
+++ b/scripts/default/openstarbound-updater
@@ -51,6 +51,14 @@ downloadOpenStarbound() {
 installOpenStarbound() {
   info "Installing OpenStarbound Linux Server version $openstarbound_latest_version ..."
   
+  # Create necessary directories if they don't exist
+  mkdir -p "$install_path/linux"
+  mkdir -p "$install_path/assets"
+  
+  # Debug before copying
+  debug "OpenStarbound staging path contents:"
+  ls -la "$openstarbound_staging_path/server_distribution/linux/"
+  
   # Check if the required OpenStarbound files exist
   if [ ! -f "$openstarbound_staging_path/server_distribution/linux/btree_repacker" ] || \
      [ ! -f "$openstarbound_staging_path/server_distribution/linux/starbound_server" ] || \
@@ -60,13 +68,19 @@ installOpenStarbound() {
   fi
   
   # Copy required OpenStarbound files to the Starbound installation path
-  cp -f "$openstarbound_staging_path/server_distribution/linux/btree_repacker" "$install_path/linux/"
-  cp -f "$openstarbound_staging_path/server_distribution/linux/starbound_server" "$install_path/linux/"
-  cp -f "$openstarbound_staging_path/server_distribution/assets/opensb.pak" "$install_path/assets/"
+  info "Copying OpenStarbound files to installation path"
+  cp -fv "$openstarbound_staging_path/server_distribution/linux/btree_repacker" "$install_path/linux/"
+  cp -fv "$openstarbound_staging_path/server_distribution/linux/starbound_server" "$install_path/linux/"
+  cp -fv "$openstarbound_staging_path/server_distribution/assets/opensb.pak" "$install_path/assets/"
   
   # Make binaries executable
   chmod +x "$install_path/linux/btree_repacker"
   chmod +x "$install_path/linux/starbound_server"
+  
+  # Debug after copying
+  debug "Final binary information:"
+  ls -la "$install_path/linux/starbound_server"
+  file "$install_path/linux/starbound_server"
   
   # Update version file
   setOpenStarboundCurrentVersion

--- a/scripts/default/openstarbound-updater
+++ b/scripts/default/openstarbound-updater
@@ -9,112 +9,112 @@ main() {
   info "openstarbound-updater complete"
 }
 
-downloadOpenStarbound() {
-  info "Downloading OpenStarbound version $openstarbound_latest_version"
+# downloadOpenStarbound() {
+#   info "Downloading OpenStarbound version $openstarbound_latest_version"
 
-  # Create OpenStarbound download directory
-  mkdir -p "$openstarbound_download_path"
+#   # Create OpenStarbound download directory
+#   mkdir -p "$openstarbound_download_path"
 
-  # Create OpenStarbound staging directory
-  mkdir -p "$openstarbound_staging_path"
+#   # Create OpenStarbound staging directory
+#   mkdir -p "$openstarbound_staging_path"
   
-  # Get download URL for the OpenStarbound Linux Server asset
-  local openstarbound_download_url
-  openstarbound_download_url=$(curl -sX GET "$openstarbound_github_api" | jq -r '.assets[] | select((.name | test("linux"; "i")) and (.name | test("server"; "i"))) | .browser_download_url')
+#   # Get download URL for the OpenStarbound Linux Server asset
+#   local openstarbound_download_url
+#   openstarbound_download_url=$(curl -sX GET "$openstarbound_github_api" | jq -r '.assets[] | select((.name | test("linux"; "i")) and (.name | test("server"; "i"))) | .browser_download_url')
 
-  if [ -z "$openstarbound_download_url" ] || [ "$openstarbound_download_url" == "null" ]; then
-    error "Failed to get download URL for OpenStarbound Linux Server"
-    return 1
-  fi
+#   if [ -z "$openstarbound_download_url" ] || [ "$openstarbound_download_url" == "null" ]; then
+#     error "Failed to get download URL for OpenStarbound Linux Server"
+#     return 1
+#   fi
   
-  # Download OpenStarbound Linux Server asset and extract
-  local openstarbound_archive_path="$openstarbound_download_path/OpenStarbound-Linux-Server.zip"
-  curl -sL "$openstarbound_download_url" -o "$openstarbound_archive_path"
+#   # Download OpenStarbound Linux Server asset and extract
+#   local openstarbound_archive_path="$openstarbound_download_path/OpenStarbound-Linux-Server.zip"
+#   curl -sL "$openstarbound_download_url" -o "$openstarbound_archive_path"
   
-  if [ ! -f "$openstarbound_archive_path" ]; then
-    error "Failed to download OpenStarbound Linux Server asset"
-    return 1
-  fi
+#   if [ ! -f "$openstarbound_archive_path" ]; then
+#     error "Failed to download OpenStarbound Linux Server asset"
+#     return 1
+#   fi
   
-  # Extract the downloaded OpenStarbound Linux Server asset
-  info "Extracting OpenStarbound Linux Server asset..."
-  tar -xzf "$openstarbound_archive_path" -C "$openstarbound_staging_path"
+#   # Extract the downloaded OpenStarbound Linux Server asset
+#   info "Extracting OpenStarbound Linux Server asset..."
+#   tar -xzf "$openstarbound_archive_path" -C "$openstarbound_staging_path"
 
-  # Remove the recently downloaded OpenStarbound Linux Server asset
-  info "Cleaning up OpenStarbound download directory..."
-  find "$openstarbound_download_path" -type f \( -iname '*linux*' -iname '*server*' \) -exec rm -f {} +
+#   # Remove the recently downloaded OpenStarbound Linux Server asset
+#   info "Cleaning up OpenStarbound download directory..."
+#   find "$openstarbound_download_path" -type f \( -iname '*linux*' -iname '*server*' \) -exec rm -f {} +
 
-  info "OpenStarbound downloaded to staging directory"
-  return 0
-}
+#   info "OpenStarbound downloaded to staging directory"
+#   return 0
+# }
 
-installOpenStarbound() {
-  info "Installing OpenStarbound Linux Server version $openstarbound_latest_version ..."
+# installOpenStarbound() {
+#   info "Installing OpenStarbound Linux Server version $openstarbound_latest_version ..."
   
-  # Create necessary directories if they don't exist
-  mkdir -p "$install_path/linux"
-  mkdir -p "$install_path/assets"
+#   # Create necessary directories if they don't exist
+#   mkdir -p "$install_path/linux"
+#   mkdir -p "$install_path/assets"
   
-  # Debug before copying
-  debug "OpenStarbound staging path contents:"
-  ls -la "$openstarbound_staging_path/server_distribution/linux/"
+#   # Debug before copying
+#   debug "OpenStarbound staging path contents:"
+#   ls -la "$openstarbound_staging_path/server_distribution/linux/"
   
-  # Check if the required OpenStarbound files exist
-  if [ ! -f "$openstarbound_staging_path/server_distribution/linux/btree_repacker" ] || \
-     [ ! -f "$openstarbound_staging_path/server_distribution/linux/starbound_server" ] || \
-     [ ! -f "$openstarbound_staging_path/server_distribution/assets/opensb.pak" ]; then
-    error "OpenStarbound files are missing in staging directory"
-    return 1
-  fi
+#   # Check if the required OpenStarbound files exist
+#   if [ ! -f "$openstarbound_staging_path/server_distribution/linux/btree_repacker" ] || \
+#      [ ! -f "$openstarbound_staging_path/server_distribution/linux/starbound_server" ] || \
+#      [ ! -f "$openstarbound_staging_path/server_distribution/assets/opensb.pak" ]; then
+#     error "OpenStarbound files are missing in staging directory"
+#     return 1
+#   fi
   
-  # Copy required OpenStarbound files to the Starbound installation path
-  info "Copying OpenStarbound files to installation path"
-  cp -fv "$openstarbound_staging_path/server_distribution/linux/btree_repacker" "$install_path/linux/"
-  cp -fv "$openstarbound_staging_path/server_distribution/linux/starbound_server" "$install_path/linux/"
-  cp -fv "$openstarbound_staging_path/server_distribution/assets/opensb.pak" "$install_path/assets/"
+#   # Copy required OpenStarbound files to the Starbound installation path
+#   info "Copying OpenStarbound files to installation path"
+#   cp -fv "$openstarbound_staging_path/server_distribution/linux/btree_repacker" "$install_path/linux/"
+#   cp -fv "$openstarbound_staging_path/server_distribution/linux/starbound_server" "$install_path/linux/"
+#   cp -fv "$openstarbound_staging_path/server_distribution/assets/opensb.pak" "$install_path/assets/"
   
-  # Make binaries executable
-  chmod +x "$install_path/linux/btree_repacker"
-  chmod +x "$install_path/linux/starbound_server"
+#   # Make binaries executable
+#   chmod +x "$install_path/linux/btree_repacker"
+#   chmod +x "$install_path/linux/starbound_server"
   
-  # Debug after copying
-  debug "Final binary information:"
-  ls -la "$install_path/linux/starbound_server"
-  file "$install_path/linux/starbound_server"
+#   # Debug after copying
+#   debug "Final binary information:"
+#   ls -la "$install_path/linux/starbound_server"
+#   file "$install_path/linux/starbound_server"
   
-  # Update version file
-  setOpenStarboundCurrentVersion
+#   # Update version file
+#   setOpenStarboundCurrentVersion
   
-  info "OpenStarbound Linux Server version $openstarbound_latest_version installed successfully"
-  return 0
-}
+#   info "OpenStarbound Linux Server version $openstarbound_latest_version installed successfully"
+#   return 0
+# }
 
-updateOpenStarbound() {
-  if [ "$USE_OPENSTARBOUND" != "true" ]; then
-    debug "OpenStarbound is disabled, skipping update"
-    return 0
-  fi
+# updateOpenStarbound() {
+#   if [ "$USE_OPENSTARBOUND" != "true" ]; then
+#     debug "OpenStarbound is disabled, skipping update"
+#     return 0
+#   fi
   
-  info "Updating OpenStarbound Linux Server..."
+#   info "Updating OpenStarbound Linux Server..."
   
-  # First check if an OpenStarbound update is available
-  if ! checkForOpenStarboundUpdates; then
-    debug "No OpenStarbound Linux Server update needed"
-    return 0
-  fi
+#   # First check if an OpenStarbound update is available
+#   if ! checkForOpenStarboundUpdates; then
+#     debug "No OpenStarbound Linux Server update needed"
+#     return 0
+#   fi
   
-  if downloadOpenStarbound; then
-    if installOpenStarbound; then
-      info "OpenStarbound Linux Server update completed successfully"
-      return 0
-    else
-      error "Failed to install OpenStarbound Linux Server"
-      return 1
-    fi
-  else
-    error "Failed to download OpenStarbound Linux Server"
-    return 1
-  fi
-}
+#   if downloadOpenStarbound; then
+#     if installOpenStarbound; then
+#       info "OpenStarbound Linux Server update completed successfully"
+#       return 0
+#     else
+#       error "Failed to install OpenStarbound Linux Server"
+#       return 1
+#     fi
+#   else
+#     error "Failed to download OpenStarbound Linux Server"
+#     return 1
+#   fi
+# }
 
 main

--- a/scripts/default/openstarbound-updater-shared
+++ b/scripts/default/openstarbound-updater-shared
@@ -59,3 +59,111 @@ setOpenStarboundCurrentVersion() {
 
   echo "$openstarbound_latest_version" > "$openstarbound_version_file_path"
 }
+
+downloadOpenStarbound() {
+  info "Downloading OpenStarbound version $openstarbound_latest_version"
+
+  # Create OpenStarbound download directory
+  mkdir -p "$openstarbound_download_path"
+
+  # Create OpenStarbound staging directory
+  mkdir -p "$openstarbound_staging_path"
+  
+  # Get download URL for the OpenStarbound Linux Server asset
+  local openstarbound_download_url
+  openstarbound_download_url=$(curl -sX GET "$openstarbound_github_api" | jq -r '.assets[] | select((.name | test("linux"; "i")) and (.name | test("server"; "i"))) | .browser_download_url')
+
+  if [ -z "$openstarbound_download_url" ] || [ "$openstarbound_download_url" == "null" ]; then
+    error "Failed to get download URL for OpenStarbound Linux Server"
+    return 1
+  fi
+  
+  # Download OpenStarbound Linux Server asset and extract
+  local openstarbound_archive_path="$openstarbound_download_path/OpenStarbound-Linux-Server.zip"
+  curl -sL "$openstarbound_download_url" -o "$openstarbound_archive_path"
+  
+  if [ ! -f "$openstarbound_archive_path" ]; then
+    error "Failed to download OpenStarbound Linux Server asset"
+    return 1
+  fi
+  
+  # Extract the downloaded OpenStarbound Linux Server asset
+  info "Extracting OpenStarbound Linux Server asset..."
+  tar -xzf "$openstarbound_archive_path" -C "$openstarbound_staging_path"
+
+  # Remove the recently downloaded OpenStarbound Linux Server asset
+  info "Cleaning up OpenStarbound download directory..."
+  find "$openstarbound_download_path" -type f \( -iname '*linux*' -iname '*server*' \) -exec rm -f {} +
+
+  info "OpenStarbound downloaded to staging directory"
+  return 0
+}
+
+installOpenStarbound() {
+  info "Installing OpenStarbound Linux Server version $openstarbound_latest_version ..."
+  
+  # Create necessary directories if they don't exist
+  mkdir -p "$install_path/linux"
+  mkdir -p "$install_path/assets"
+  
+  # Debug before copying
+  debug "OpenStarbound staging path contents:"
+  ls -la "$openstarbound_staging_path/server_distribution/linux/"
+  
+  # Check if the required OpenStarbound files exist
+  if [ ! -f "$openstarbound_staging_path/server_distribution/linux/btree_repacker" ] || \
+     [ ! -f "$openstarbound_staging_path/server_distribution/linux/starbound_server" ] || \
+     [ ! -f "$openstarbound_staging_path/server_distribution/assets/opensb.pak" ]; then
+    error "OpenStarbound files are missing in staging directory"
+    return 1
+  fi
+  
+  # Copy required OpenStarbound files to the Starbound installation path
+  info "Copying OpenStarbound files to installation path"
+  cp -fv "$openstarbound_staging_path/server_distribution/linux/btree_repacker" "$install_path/linux/"
+  cp -fv "$openstarbound_staging_path/server_distribution/linux/starbound_server" "$install_path/linux/"
+  cp -fv "$openstarbound_staging_path/server_distribution/assets/opensb.pak" "$install_path/assets/"
+  
+  # Make binaries executable
+  chmod +x "$install_path/linux/btree_repacker"
+  chmod +x "$install_path/linux/starbound_server"
+  
+  # Debug after copying
+  debug "Final binary information:"
+  ls -la "$install_path/linux/starbound_server"
+  file "$install_path/linux/starbound_server"
+  
+  # Update version file
+  setOpenStarboundCurrentVersion
+  
+  info "OpenStarbound Linux Server version $openstarbound_latest_version installed successfully"
+  return 0
+}
+
+updateOpenStarbound() {
+  if [ "$USE_OPENSTARBOUND" != "true" ]; then
+    debug "OpenStarbound is disabled, skipping update"
+    return 0
+  fi
+  
+  info "Updating OpenStarbound Linux Server..."
+  
+  # First check if an OpenStarbound update is available
+  if ! checkForOpenStarboundUpdates; then
+    debug "No OpenStarbound Linux Server update needed"
+    return 0
+  fi
+  
+  if downloadOpenStarbound; then
+    if installOpenStarbound; then
+      info "OpenStarbound Linux Server update completed successfully"
+      return 0
+    else
+      error "Failed to install OpenStarbound Linux Server"
+      return 1
+    fi
+  else
+    error "Failed to download OpenStarbound Linux Server"
+    return 1
+  fi
+}

--- a/scripts/default/starbound-bootstrap
+++ b/scripts/default/starbound-bootstrap
@@ -13,11 +13,11 @@ main() {
   initCrontab
 
   # Ensure OpenStarbound (if enabled) is installed/updated after Starbound is installed/updated
-  if [ "$USE_OPENSTARBOUND" == "true" ]; then
-    supervisorctl start update-sequence:*
-  else
+  # if [ "$USE_OPENSTARBOUND" == "true" ]; then
+  #   supervisorctl start update-sequence:*
+  # else
     supervisorctl start starbound-updater
-  fi
+  # fi
   info "Bootstrap complete"
 }
 

--- a/scripts/default/starbound-updater-shared
+++ b/scripts/default/starbound-updater-shared
@@ -1,7 +1,7 @@
 #!/bin/bash
 . "$(dirname "$0")/common"
 . "$(dirname "$0")/defaults"
-. "$(dirname "$0")/openstarbound-updater"
+# . "$(dirname "$0")/openstarbound-updater"
 . "$(dirname "$0")/openstarbound-updater-shared"
 
 pidfile=$starbound_updater_pidfile

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -87,6 +87,7 @@ autostart=false
 autorestart=false
 startsecs=0
 priority=20
+depends_on=starbound-updater
 
 [group:update-sequence]
 programs=starbound-updater,openstarbound-updater

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -72,7 +72,6 @@ stdout_logfile_maxbytes=2MB
 stderr_logfile_maxbytes=2MB
 autostart=false
 autorestart=false
-startsecs=0
 priority=10
 
 [program:openstarbound-updater]
@@ -85,7 +84,6 @@ stdout_logfile_maxbytes=2MB
 stderr_logfile_maxbytes=2MB
 autostart=false
 autorestart=false
-startsecs=0
 priority=20
 depends_on=starbound-updater
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -87,9 +87,9 @@ autorestart=false
 priority=20
 depends_on=starbound-updater
 
-[group:update-sequence]
-programs=starbound-updater,openstarbound-updater
-priority=100
+; [group:update-sequence]
+; programs=starbound-updater,openstarbound-updater
+; priority=100
 
 # [program:starbound-backup]
 # user=starbound

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -85,7 +85,7 @@ stderr_logfile_maxbytes=2MB
 autostart=false
 autorestart=false
 priority=20
-depends_on=starbound-updater
+; depends_on=starbound-updater
 
 ; [group:update-sequence]
 ; programs=starbound-updater,openstarbound-updater


### PR DESCRIPTION
Finally found the issue after a decent amount of hunt-and-peck debugging.

Merging back into 'fix' branch to retain the "solution" - then clean-up will occur in subsequent commits in the 'fix' branch.

As it turns out, there was a mix of a race condition and an inadvertent function-sourcing issue that triggered premature installation of OpenStarbound (when OpenStarbound is "enabled").

Previously, "starbound-updater" sourced "openstarbound-updater" directly. This would trigger a check for OpenStarbound version, see it was not present, trigger an "install" of OpenStarbound (i.e. copy the OpenStarbound-specific files from the OpenStarbound "staging" area and then put them into place under the eventual Starbound server installation directories). 

Meanwhile, a race condition was also layered atop this (though not consistently consequential). Supervisor would launch "openstarbound-updater" as a separate program, leading the OpenStarbound install/update routines to start twice (and often in parallel with the "starbound-updater" invocation mentioned earlier). Sometimes this installation would finish before Starbound had finished installing.

To address each: 

- The "starbound-updater-shared" script no longer sources "openstarbound-updater"
- The Supervisor program entry for "openstarbound-updater-shared" (in "supervisord.conf") had picked up 'depends_on=starbound-updater' as part of debugging -- this is now removed, letting "starbound-updater" program/script remain as the single point of control for installs/updates of both Starbound and OpenStarbound

As a result, the workflow is now...

- "starbound-updater" runs, checks and applies a Starbound update if needed
- Only after that completes, "starbound-updater" calls the shared function to update or install OpenStarbound (if OpenStarbound is enabled)
- "starbound-updater" exits and Supervisor starts the game server cleanly

Testing shows a single orderly update pass and a clean server start on every container run/recreate