### PR TITLE
feature/steamguard support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /.idea
-/.vs/*
+/.vs/
 /game
+/secrets/
+/staging/
 steam_username.txt
 steam_password.txt
 starbound_rcon_password.txt

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ All environment variables prefixed with `SERVER_` are the available Starbound/Op
 > [!IMPORTANT]
 > If [Steam Guard](https://help.steampowered.com/en/faqs/view/06B0-26E6-2CF8-254C) is enabled on the Steam account used for deployment, `USE_STEAMGUARD` ***must*** be set to "true" (default is "false") and the container service ***must*** allow for interactive shell access (e.g., `stdin_open: true` and `tty: true` in [docker-compose](#docker-compose))
 
-For Steam accounts that have Steam Guard enabled, connect to the container's interactive shell to provide a valid Steam Guard code when prompted. The container will wait for a valid Steam Guard code, with the number of seconds to wait defined by `STEAMGUARD_TIMEOUT` (default is "300"). If the timeout is reached without a valid entry of a Steam Guard code, the authentication routine will exit and the game server deployment process will terminate.
+For Steam accounts that have Steam Guard enabled, connect to the container's interactive shell to provide a valid Steam Guard code when prompted. The container will wait for a valid Steam Guard code, with the number of seconds to wait defined by `STEAMGUARD_TIMEOUT` (default is "300"). If the timeout is reached without a valid entry of a Steam Guard code, the authentication routine will exit and the game server deployment process will terminate after 3 cycles of this timeout (controlled by the container service's `restart` policy).
 
 Successful entry of the Steam Guard code will be cached in the 'steam-data' volume defined in [docker-compose](#docker-compose) and the game server will be able to install/update for a duration before needing to enter the Steam Guard code again (provided that the volume's content remains intact).
 
@@ -133,7 +133,7 @@ services:
     image: ghcr.io/knaledge/openstarbound-server:latest
     container_name: starbound-server
     hostname: starbound
-    restart: unless-stopped
+    restart: on-failure:3                # Restart the container up to 3 times on failure - preventing infinite loop if Steam Guard auth fails
     stop_grace_period: 2m
     cap_add:
       - sys_nice

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ All environment variables prefixed with `SERVER_` are the available Starbound/Op
 | `PGID`                            |          | `4711`              | integer               | Group ID to run the game server processes under (file permission)                                                          |
 | `LOG_LEVEL`                       |          | `50`                | integer (0-50)        | Filter the logging from Supervisor in container (0=none, 5=fatal, 10=critical, 20=error, 30=warn, 40=info, 50=debug)       |
 | `USE_STEAMGUARD`                  |          | `false`             | boolean (true, false) | Enable Steam Guard authentication for Steam accounts                                                                       |
-| `STEAMGUARD_MAX_ATTEMPTS`         |          | `3`                 | integer               | Number of attempts to enter a valid Steam Guard code before terminating the game server deployment                         |
+| `STEAMGUARD_TIMEOUT`              |          | `300`               | integer               | Number of seconds to wait for a valid Steam Guard code before exiting (and failing the deployment)                         |
 | `GAME_BRANCH`                     |          | `public`            | string                | Steam branch (eg. testing) to utilize for the game server                                                                  |
 | `STEAMCMD_ARGS`                   |          | `validate`          | string                | Additional SteamCMD arguments to be used when installing/updating the game server                                          |
 | `UPDATE_CRON`                     |          | `0 3 * * 0`         | string (cron format)  | Update game server files on a schedule via cron (e.g., `*/30 * * * *` checks for updates every 30 minutes)                 |
@@ -82,7 +82,7 @@ All environment variables prefixed with `SERVER_` are the available Starbound/Op
 > [!IMPORTANT]
 > If [Steam Guard](https://help.steampowered.com/en/faqs/view/06B0-26E6-2CF8-254C) is enabled on the Steam account used for deployment, `USE_STEAMGUARD` ***must*** be set to "true" (default is "false") and the container service ***must*** allow for interactive shell access (e.g., `stdin_open: true` and `tty: true` in [docker-compose](#docker-compose))
 
-For Steam accounts that have Steam Guard enabled, connect to the container's interactive shell to provide a valid Steam Guard code when prompted. The container will wait for a valid Steam Guard code, with the number of permitted attempts defined by `STEAMGUARD_MAX_ATTEMPTS` (default is "3"). If the maximum attempts are reached without a valid entry of a Steam Guard code, the game server deployment process will terminate.
+For Steam accounts that have Steam Guard enabled, connect to the container's interactive shell to provide a valid Steam Guard code when prompted. The container will wait for a valid Steam Guard code, with the number of seconds to wait defined by `STEAMGUARD_TIMEOUT` (default is "300"). If the timeout is reached without a valid entry of a Steam Guard code, the authentication routine will exit and the game server deployment process will terminate.
 
 Successful entry of the Steam Guard code will be cached in the 'steam-data' volume defined in the [docker-compose](#docker-compose) and the game server will be able to update for a duration before needing to enter the Steam Guard code again.
 
@@ -154,7 +154,7 @@ services:
       - BACKUP_MAX_COUNT=7               # Default is retain a max of 7 backups before overwriting the oldest
       - log_level=50                     # Default is "50" (debug); 0-100 (0=none, 100=all)  
       - USE_STEAMGUARD=false             # Default is "false"; set to "true" if the Steam account is protected by Steam Guard
-      - STEAMGUARD_MAX_ATTEMPTS=3        # Default is "3"; max attempts to enter valid Steam Guard code before terminating game server deployment
+      - STEAMGUARD_TIMEOUT=300           # Default is "300" (seconds); amount of time to wait for a valid Steam Guard code before exiting (and failing the deployment)
       - SERVER_NAME=Starbound Server
       - SERVER_PORT=21025                # Match with 'ports' definition; default is "21025"
       - SERVER_RCON_PORT=21026           # Match with 'ports' definition; default is "21026"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ All environment variables prefixed with `SERVER_` are the available Starbound/Op
 
 For Steam accounts that have Steam Guard enabled, connect to the container's interactive shell to provide a valid Steam Guard code when prompted. The container will wait for a valid Steam Guard code, with the number of seconds to wait defined by `STEAMGUARD_TIMEOUT` (default is "300"). If the timeout is reached without a valid entry of a Steam Guard code, the authentication routine will exit and the game server deployment process will terminate.
 
-Successful entry of the Steam Guard code will be cached in the 'steam-data' volume defined in the [docker-compose](#docker-compose) and the game server will be able to update for a duration before needing to enter the Steam Guard code again.
+Successful entry of the Steam Guard code will be cached in the 'steam-data' volume defined in [docker-compose](#docker-compose) and the game server will be able to install/update for a duration before needing to enter the Steam Guard code again (provided that the volume's content remains intact).
 
 ### Secrets Storage
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ Simply create a directory on the game server's host itself to store the "Host Se
 
 By default the volumes are created with the **PUID** and **PGID** "4711" and may be overridden by defining the environment variables `PUID` and `PGID` via `docker-compose` ([example](#docker-compose))
 
-| Volume             | Description                                   |
-|--------------------|-----------------------------------------------|
-| `/opt/starbound`   | Game server files (including Steam content)   |
+| Volume                  | Description                                 |
+|-------------------------|---------------------------------------------|
+| `/opt/starbound`        | Game server files                           |
+| `/home/starbound/Steam` | Steam content ('starbound' user directory)  |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Starbound + OpenStarbound Dedicated Server (Linux)
 
 ## Overview
-Docker-centric method of deploying a [Starbound](https://www.playstarbound.com) game server (Linux), weaving in the option to also deploy [OpenStarbound](https://github.com/OpenStarbound/OpenStarbound) - an unaffiliated fan-maintained project that extends the life of Starbound through bug fixes, engine optimizations, and new features introduced to the core experience.
+Docker-centric method of deploying a [Starbound](https://www.playstarbound.com) game server (Linux), weaving in the option to also deploy [OpenStarbound](https://github.com/OpenStarbound/OpenStarbound) - an unaffiliated fan-maintained project that extends the life of Starbound through bug fixes, engine optimizations, and new features introduced to the core Starbound experience.
 
 ### Features
 - **Core functions** include: game server installation/updates, startup, shutdown, maintenance, and backups
@@ -53,9 +53,9 @@ All environment variables prefixed with `SERVER_` are the available Starbound/Op
 | `PUID`                            |          | `4711`              | integer               | User ID to run the game server processes under (file permission)                                                           |
 | `PGID`                            |          | `4711`              | integer               | Group ID to run the game server processes under (file permission)                                                          |
 | `LOG_LEVEL`                       |          | `50`                | integer (0-50)        | Filter the logging from Supervisor in container (0=none, 5=fatal, 10=critical, 20=error, 30=warn, 40=info, 50=debug)       |
-| `USE_STEAMGUARD`                  |          | `false`             | boolean (true, false) | Enable Steam Guard authentication for Steam accounts                                                                       |
+| `STEAMGUARD_REQUIRED`             |          | `false`             | boolean (true, false) | Enable if Steam Guard authentication is required for the Steam account being used for game server deployment               |
 | `STEAMGUARD_TIMEOUT`              |          | `300`               | integer               | Number of seconds to wait for a valid Steam Guard code before exiting (and failing the deployment)                         |
-| `GAME_BRANCH`                     |          | `public`            | string                | Steam branch (eg. testing) to utilize for the game server                                                                  |
+| `GAME_BRANCH`                     |          | `public`            | string                | Steam branch to utilize for the game server                                                                                |
 | `STEAMCMD_ARGS`                   |          | `validate`          | string                | Additional SteamCMD arguments to be used when installing/updating the game server                                          |
 | `UPDATE_CRON`                     |          | `0 3 * * 0`         | string (cron format)  | Update game server files on a schedule via cron (e.g., `*/30 * * * *` checks for updates every 30 minutes)                 |
 | `UPDATE_CHECK_PLAYERS`            |          | `true`              | boolean               | Check if any players are connected to the game server prior to updating the game server                                    |
@@ -80,11 +80,11 @@ All environment variables prefixed with `SERVER_` are the available Starbound/Op
 #### Steam Credentials
 
 > [!IMPORTANT]
-> If [Steam Guard](https://help.steampowered.com/en/faqs/view/06B0-26E6-2CF8-254C) is enabled on the Steam account used for deployment, `USE_STEAMGUARD` ***must*** be set to "true" (default is "false") and the container service ***must*** allow for interactive shell access (e.g., `stdin_open: true` and `tty: true` in [docker-compose](#docker-compose))
+> If [Steam Guard](https://help.steampowered.com/en/faqs/view/06B0-26E6-2CF8-254C) is enabled on the Steam account used for game server deployment, `STEAMGUARD_REQUIRED` ***must*** be set to "true" (default is "false") and the container service ***must*** allow for interactive shell access (e.g., `stdin_open: true` and `tty: true` in [docker-compose](#docker-compose))
 
-For Steam accounts that have Steam Guard enabled, connect to the container's interactive shell to provide a valid Steam Guard code when prompted. The container will wait for a valid Steam Guard code, with the number of seconds to wait defined by `STEAMGUARD_TIMEOUT` (default is "300"). If the timeout is reached without a valid entry of a Steam Guard code, the authentication routine will exit and the game server deployment process will terminate after 3 cycles of this timeout (controlled by the container service's `restart` policy).
+For Steam accounts that have Steam Guard enabled, connect to the container's interactive shell to provide a valid Steam Guard code when prompted. The container will wait for a valid Steam Guard code for a configurable period of time, with the number of seconds to wait defined by `STEAMGUARD_TIMEOUT` (default is "300" - i.e. 5 minutes). If the timeout is reached before valid entry of a Steam Guard code, the authentication routine will exit, the game server deployment process will terminate, and the container itself will stop (regardless of the container service's `restart` policy).
 
-Successful entry of the Steam Guard code will be cached in the 'steam-data' volume defined in [docker-compose](#docker-compose) and the game server will be able to install/update for a duration before needing to enter the Steam Guard code again (provided that the volume's content remains intact).
+Successful entry of a valid Steam Guard code will be cached in the 'steam-data' [volume](#volumes) defined in [docker-compose](#docker-compose). Provided that the volume's content remains intact, the game server will be able to install/update for a duration before needing to enter the Steam Guard code again.
 
 ### Secrets Storage
 
@@ -128,8 +128,8 @@ Current [docker-compose.yml](./docker-compose.yml)
 ```yml
 services:
   starbound:
-    tty: true                           # Required for Steam Guard support (able to be removed if Steam Guard is disabled on the Steam account)
-    stdin_open: true                    # Required for Steam Guard support (able to be removed if Steam Guard is disabled on the Steam account)
+    tty: true                            # Required for Steam Guard support (able to be removed if Steam Guard is disabled on the Steam account)
+    stdin_open: true                     # Required for Steam Guard support (able to be removed if Steam Guard is disabled on the Steam account)
     image: ghcr.io/knaledge/openstarbound-server:latest
     container_name: starbound-server
     hostname: starbound
@@ -154,7 +154,7 @@ services:
       - BACKUP_CRON=0 4 * * *            # Default is backup every day at 4 AM (server host time)
       - BACKUP_MAX_COUNT=7               # Default is retain a max of 7 backups before overwriting the oldest
       - log_level=50                     # Default is "50" (debug); 0-100 (0=none, 100=all)  
-      - USE_STEAMGUARD=false             # Default is "false"; set to "true" if the Steam account is protected by Steam Guard
+      - STEAMGUARD_REQUIRED=false        # Default is "false"; set to "true" if the Steam account is protected by Steam Guard
       - STEAMGUARD_TIMEOUT=300           # Default is "300" (seconds); amount of time to wait for a valid Steam Guard code before exiting (and failing the deployment)
       - SERVER_NAME=Starbound Server
       - SERVER_PORT=21025                # Match with 'ports' definition; default is "21025"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ All environment variables prefixed with `SERVER_` are the available Starbound/Op
 > [!IMPORTANT]
 > If [Steam Guard](https://help.steampowered.com/en/faqs/view/06B0-26E6-2CF8-254C) is enabled on the Steam account used for deployment, `USE_STEAMGUARD` ***must*** be set to "true" (default is "false") and the container service ***must*** allow for interactive shell access (e.g., `stdin_open: true` and `tty: true` in [docker-compose](#docker-compose))
 
-For Steam accounts that have Steam Guard enabled, connect to the container's interactive shell to provide a valid Steam Guard code when prompted. The container will wait for a valid code, with the number of permitted attempts defined by `STEAMGUARD_MAX_ATTEMPTS` (default is "3"). If the maximum attempts are reached without a valid entry of a Steam Guard code, the game server deployment process will terminate.
+For Steam accounts that have Steam Guard enabled, connect to the container's interactive shell to provide a valid Steam Guard code when prompted. The container will wait for a valid Steam Guard code, with the number of permitted attempts defined by `STEAMGUARD_MAX_ATTEMPTS` (default is "3"). If the maximum attempts are reached without a valid entry of a Steam Guard code, the game server deployment process will terminate.
 
 Successful entry of the Steam Guard code will be cached in the 'steam-data' volume defined in the [docker-compose](#docker-compose) and the game server will be able to update for a duration before needing to enter the Steam Guard code again.
 
@@ -127,8 +127,8 @@ Current [docker-compose.yml](./docker-compose.yml)
 ```yml
 services:
   starbound:
-    tty: true
-    stdin_open: true
+    tty: true                           # Required for Steam Guard support (able to be removed if Steam Guard is disabled on the Steam account)
+    stdin_open: true                    # Required for Steam Guard support (able to be removed if Steam Guard is disabled on the Steam account)
     image: ghcr.io/knaledge/openstarbound-server:latest
     container_name: starbound-server
     hostname: starbound

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - BACKUP_MAX_COUNT=7               # Default is retain a max of 7 backups before overwriting the oldest
       - log_level=50                     # Default is "50" (debug); 0-100 (0=none, 100=all)  
       - USE_STEAMGUARD=false             # Default is "false"; set to "true" if the Steam account is protected by Steam Guard
-      - STEAMGUARD_MAX_ATTEMPTS=3        # Default is "3"; max attempts to enter valid Steam Guard code before terminating game server deployment
+      - STEAMGUARD_TIMEOUT=300           # Default is "300" (seconds); amount of time to wait for a valid Steam Guard code before exiting (and failing the deployment)
       - SERVER_NAME=Starbound Server
       - SERVER_PORT=21025                # Match with 'ports' definition; default is "21025"
       - SERVER_RCON_PORT=21026           # Match with 'ports' definition; default is "21026"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       - BACKUP_CRON=0 4 * * *            # Default is backup every day at 4 AM (server host time)
       - BACKUP_MAX_COUNT=7               # Default is retain a max of 7 backups before overwriting the oldest
       - log_level=50                     # Default is "50" (debug); 0-100 (0=none, 100=all)  
+      - USE_STEAMGUARD=false             # Default is "false"; set to "true" if the Steam account is protected by Steam Guard
+      - STEAMGUARD_MAX_ATTEMPTS=3        # Default is "3"; max attempts to enter valid Steam Guard code before terminating game server deployment
       - SERVER_NAME=Starbound Server
       - SERVER_PORT=21025                # Match with 'ports' definition; default is "21025"
       - SERVER_RCON_PORT=21026           # Match with 'ports' definition; default is "21026"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   starbound:
+    tty: true
+    stdin_open: true
     image: ghcr.io/knaledge/openstarbound-server:latest
     container_name: starbound-server
     hostname: starbound
@@ -11,7 +13,8 @@ services:
       - "21025:21025/tcp"                # Match with 'SERVER_PORT' value
       - "21026:21026/tcp"                # Match with 'SERVER_RCON_PORT' value
     volumes:
-      - /path/to/volume:/opt/starbound
+      - /path/to/volume/for/game-data:/opt/starbound
+      - /path/to/volume/for/steam-data:/home/starbound/Steam
     secrets:
       - steam_username
       - steam_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - BACKUP_CRON=0 4 * * *            # Default is backup every day at 4 AM (server host time)
       - BACKUP_MAX_COUNT=7               # Default is retain a max of 7 backups before overwriting the oldest
       - log_level=50                     # Default is "50" (debug); 0-100 (0=none, 100=all)  
-      - USE_STEAMGUARD=false             # Default is "false"; set to "true" if the Steam account is protected by Steam Guard
+      - STEAMGUARD_REQUIRED=false        # Default is "false"; set to "true" if the Steam account is protected by Steam Guard
       - STEAMGUARD_TIMEOUT=300           # Default is "300" (seconds); amount of time to wait for a valid Steam Guard code before exiting (and failing the deployment)
       - SERVER_NAME=Starbound Server
       - SERVER_PORT=21025                # Match with 'ports' definition; default is "21025"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: ghcr.io/knaledge/openstarbound-server:latest
     container_name: starbound-server
     hostname: starbound
-    restart: unless-stopped
+    restart: on-failure:3                # Restart the container up to 3 times on failure - preventing infinite loop if Steam Guard auth fails
     stop_grace_period: 2m
     cap_add:
       - sys_nice

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   starbound:
-    tty: true
-    stdin_open: true
+    tty: true                            # Required for Steam Guard support (able to be removed if Steam Guard is disabled on the Steam account)
+    stdin_open: true                     # Required for Steam Guard support (able to be removed if Steam Guard is disabled on the Steam account)
     image: ghcr.io/knaledge/openstarbound-server:latest
     container_name: starbound-server
     hostname: starbound

--- a/scripts/default/bootstrap
+++ b/scripts/default/bootstrap
@@ -7,7 +7,7 @@ main() {
   createFolders
   applyPermissions
   setupSyslog
-  steamGuardAuth
+  steamGuardAuth # Function allowing for Steam Guard code entry in a pre-Supervisor interactive shell; traversed if 'USE_STEAMGUARD' is set to "true"
   exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
 }
 

--- a/scripts/default/bootstrap
+++ b/scripts/default/bootstrap
@@ -7,6 +7,7 @@ main() {
   createFolders
   applyPermissions
   setupSyslog
+  steamGuardAuth
   exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
 }
 

--- a/scripts/default/bootstrap
+++ b/scripts/default/bootstrap
@@ -7,7 +7,7 @@ main() {
   createFolders
   applyPermissions
   setupSyslog
-  steamGuardAuth # Allows for Steam Guard code entry in a pre-Supervisor interactive shell; traversed if 'USE_STEAMGUARD' is set to "true"
+  steamGuardAuth # Allows for Steam Guard code entry in a pre-Supervisor interactive shell; traversed if 'STEAMGUARD_REQUIRED' is set to "true"
     exit_code=$?
 
     if [ "$exit_code" -eq 42 ]; then

--- a/scripts/default/bootstrap
+++ b/scripts/default/bootstrap
@@ -7,7 +7,17 @@ main() {
   createFolders
   applyPermissions
   setupSyslog
-  steamGuardAuth # Function allowing for Steam Guard code entry in a pre-Supervisor interactive shell; traversed if 'USE_STEAMGUARD' is set to "true"
+  steamGuardAuth # Allows for Steam Guard code entry in a pre-Supervisor interactive shell; traversed if 'USE_STEAMGUARD' is set to "true"
+    exit_code=$?
+
+    if [ "$exit_code" -eq 42 ]; then
+      error "SteamCMD authentication failed or timed out - terminating deployment and stopping container"
+      exit 0  # exit cleanly so that the container 'restart' policy does not count it as a "failure" and stops the container
+    elif [ "$exit_code" -ne 0 ]; then
+      error "Unexpected error during 'bootstrap' routine (exit code: $exit_code) - restarting container..."
+      exit $exit_code  # defer to the container restart policy for all other failures/exit codes
+    fi
+
   exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
 }
 

--- a/scripts/default/common
+++ b/scripts/default/common
@@ -116,3 +116,108 @@ checkRunning() {
     return 1
   fi
 }
+
+# steamGuardAuth() {
+#   if [ "$USE_STEAMGUARD" == "true" ]; then
+#     info "Steam Guard authentication enabled - beginning interactive SteamCMD login..."
+
+#     if [ ! -t 0 ]; then
+#       # warn "stdin is not a TTY; interactive input may not work! Did you forget to run with -it or tty: true?"
+#       error "stdin is not a TTY; cannot proceed with interactive Steam Guard login. Exiting."
+#       exit 1
+#     fi
+
+#     # Check if Steam credentials from Docker secrets are available
+#     if [ ! -f "/run/secrets/steam_username" ] || [ ! -f "/run/secrets/steam_password" ]; then
+#       error "Missing Docker secrets: 'steam_username' and/or 'steam_password'"
+#       exit 1
+#     fi
+
+#     # Read Steam credentials from Docker secrets
+#     STEAM_USERNAME=$(cat /run/secrets/steam_username)
+#     STEAM_PASSWORD=$(cat /run/secrets/steam_password)
+
+#     # Set maximum number of attempts for SteamCMD login before failing
+#     ATTEMPT=1
+#     MAX_ATTEMPTS=${STEAMGUARD_MAX_RETRIES:-3}
+#     LOGIN_SUCCESS=false
+
+#     # Loop to attempt SteamCMD login while Steam Guard is enabled
+#     while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+#       info "SteamCMD login attempt $ATTEMPT of $MAX_ATTEMPTS..."
+#       if steamcmd +login "$STEAM_USERNAME" "$STEAM_PASSWORD" +quit; then
+#         info "SteamCMD authentication with Steam Guard successful - proceeding with install/update of game server..."
+#         LOGIN_SUCCESS=true
+#         break
+#       else
+#         warn "SteamCMD login failed."
+#         warn "If Steam Guard requested, enter code interactively at prompt"
+#       fi
+#       ATTEMPT=$((ATTEMPT + 1))
+#     done
+
+#     if [ "$LOGIN_SUCCESS" = false ]; then
+#       error "SteamCMD login failed after $MAX_ATTEMPTS attempts - exiting"
+#       exit 2
+#     fi
+#   else
+#     info "Steam Guard authentication is disabled - skipping..."
+#   fi
+# }
+
+steamGuardAuth() {
+  if [ "$USE_STEAMGUARD" == "true" ]; then
+    info "Steam Guard authentication enabled - beginning interactive SteamCMD login..."
+
+    if [ ! -t 0 ]; then
+      # warn "stdin is not a TTY; interactive input may not work! Did you forget to run with -it or tty: true?"
+      error "stdin is not a TTY; cannot proceed with interactive Steam Guard login. Exiting."
+      exit 1
+    fi
+
+    # Check if Steam credentials from Docker secrets are available
+    if [ ! -f "/run/secrets/steam_username" ] || [ ! -f "/run/secrets/steam_password" ]; then
+      error "Missing Docker secrets: 'steam_username' and/or 'steam_password'"
+      exit 1
+    fi
+
+    # Read Steam credentials from Docker secrets
+    STEAM_USERNAME=$(cat /run/secrets/steam_username)
+    STEAM_PASSWORD=$(cat /run/secrets/steam_password)
+
+    # Switch to 'starbound' user and run SteamCMD login logic under that user
+    su starbound -c "
+      export HOME=/home/starbound
+      ATTEMPT=1
+      MAX_ATTEMPTS=\${STEAMGUARD_MAX_RETRIES:-3}
+      LOGIN_SUCCESS=false
+
+      # Loop to attempt SteamCMD login while Steam Guard is enabled
+      while [ \$ATTEMPT -le \$MAX_ATTEMPTS ]; do
+        echo \"INFO - SteamCMD login attempt \$ATTEMPT of \$MAX_ATTEMPTS...\"
+        if steamcmd +login \"$STEAM_USERNAME\" \"$STEAM_PASSWORD\" +quit; then
+          echo \"INFO - SteamCMD authentication with Steam Guard successful - proceeding with install/update of game server...\"
+          LOGIN_SUCCESS=true
+          break
+        else
+          echo \"WARN - SteamCMD login failed.\"
+          echo \"WARN - If Steam Guard requested, enter code interactively at prompt.\"
+        fi
+        ATTEMPT=\$((ATTEMPT + 1))
+      done
+
+      if [ \"\$LOGIN_SUCCESS\" = false ]; then
+        echo \"ERROR - SteamCMD login failed after \$MAX_ATTEMPTS attempts - exiting.\"
+        exit 2
+      fi
+    "
+
+    if [ $? -ne 0 ]; then
+      error "SteamCMD login (as starbound) failed or exited with error."
+      exit 2
+    fi
+
+  else
+    info "Steam Guard authentication is disabled - skipping..."
+  fi
+}

--- a/scripts/default/common
+++ b/scripts/default/common
@@ -150,12 +150,12 @@ steamGuardAuth() {
     "
 
     if [ $? -ne 0 ]; then
-      error "SteamCMD authentication (as 'starbound' user) failed - returning..."
+      error "SteamCMD authentication (as 'starbound' user) failed or timed out - returning..."
       return 42
     fi
 
   else
-    info "Environment variable 'STEAMGUARD_REQUIRED' is set to 'false' - skipping..."
+    info "Environment variable 'STEAMGUARD_REQUIRED' is set to 'false' - skipping bootstrap SteamCMD + Steam Guard authentication routine..."
   fi
 
   return 0

--- a/scripts/default/common
+++ b/scripts/default/common
@@ -117,54 +117,6 @@ checkRunning() {
   fi
 }
 
-# steamGuardAuth() {
-#   if [ "$USE_STEAMGUARD" == "true" ]; then
-#     info "Steam Guard authentication enabled - beginning interactive SteamCMD login..."
-
-#     if [ ! -t 0 ]; then
-#       # warn "stdin is not a TTY; interactive input may not work! Did you forget to run with -it or tty: true?"
-#       error "stdin is not a TTY; cannot proceed with interactive Steam Guard login. Exiting."
-#       exit 1
-#     fi
-
-#     # Check if Steam credentials from Docker secrets are available
-#     if [ ! -f "/run/secrets/steam_username" ] || [ ! -f "/run/secrets/steam_password" ]; then
-#       error "Missing Docker secrets: 'steam_username' and/or 'steam_password'"
-#       exit 1
-#     fi
-
-#     # Read Steam credentials from Docker secrets
-#     STEAM_USERNAME=$(cat /run/secrets/steam_username)
-#     STEAM_PASSWORD=$(cat /run/secrets/steam_password)
-
-#     # Set maximum number of attempts for SteamCMD login before failing
-#     ATTEMPT=1
-#     MAX_ATTEMPTS=${STEAMGUARD_MAX_RETRIES:-3}
-#     LOGIN_SUCCESS=false
-
-#     # Loop to attempt SteamCMD login while Steam Guard is enabled
-#     while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-#       info "SteamCMD login attempt $ATTEMPT of $MAX_ATTEMPTS..."
-#       if steamcmd +login "$STEAM_USERNAME" "$STEAM_PASSWORD" +quit; then
-#         info "SteamCMD authentication with Steam Guard successful - proceeding with install/update of game server..."
-#         LOGIN_SUCCESS=true
-#         break
-#       else
-#         warn "SteamCMD login failed."
-#         warn "If Steam Guard requested, enter code interactively at prompt"
-#       fi
-#       ATTEMPT=$((ATTEMPT + 1))
-#     done
-
-#     if [ "$LOGIN_SUCCESS" = false ]; then
-#       error "SteamCMD login failed after $MAX_ATTEMPTS attempts - exiting"
-#       exit 2
-#     fi
-#   else
-#     info "Steam Guard authentication is disabled - skipping..."
-#   fi
-# }
-
 steamGuardAuth() {
   if [ "$USE_STEAMGUARD" == "true" ]; then
     info "Steam Guard authentication enabled - beginning interactive SteamCMD login..."

--- a/scripts/default/common
+++ b/scripts/default/common
@@ -119,11 +119,10 @@ checkRunning() {
 
 steamGuardAuth() {
   if [ "$USE_STEAMGUARD" == "true" ]; then
-    info "Steam Guard authentication enabled - beginning interactive SteamCMD login..."
+    info "Environment variable 'USE_STEAMGUARD' is set to 'true' - beginning interactive SteamCMD login..."
 
     if [ ! -t 0 ]; then
-      # warn "stdin is not a TTY; interactive input may not work! Did you forget to run with -it or tty: true?"
-      error "stdin is not a TTY; cannot proceed with interactive Steam Guard login. Exiting."
+      error "stdin is not interactive/TTY; cannot proceed with interactive Steam Guard login - exiting..."
       exit 1
     fi
 
@@ -132,44 +131,30 @@ steamGuardAuth() {
       error "Missing Docker secrets: 'steam_username' and/or 'steam_password'"
       exit 1
     fi
-
-    # Read Steam credentials from Docker secrets
+    
+    # Set environment variable values for SteamCMD authentication and Steam credentials using Docker secrets
     STEAM_USERNAME=$(cat /run/secrets/steam_username)
     STEAM_PASSWORD=$(cat /run/secrets/steam_password)
+    STEAMGUARD_TIMEOUT=${STEAMGUARD_TIMEOUT:-300} # Default timeout for Steam Guard authentication before exiting routine
 
-    # Switch to 'starbound' user and run SteamCMD login logic under that user
     su starbound -c "
       export HOME=/home/starbound
-      ATTEMPT=1
-      MAX_ATTEMPTS=\${STEAMGUARD_MAX_ATTEMPTS:-3}
-      LOGIN_SUCCESS=false
-
-      # Loop to attempt SteamCMD login while Steam Guard is enabled
-      while [ \$ATTEMPT -le \$MAX_ATTEMPTS ]; do
-        echo \"INFO - SteamCMD login attempt \$ATTEMPT of \$MAX_ATTEMPTS...\"
-        if steamcmd +login \"$STEAM_USERNAME\" \"$STEAM_PASSWORD\" +quit; then
-          echo \"INFO - SteamCMD authentication with Steam Guard successful - proceeding with install/update of game server...\"
-          LOGIN_SUCCESS=true
-          break
-        else
-          echo \"WARN - SteamCMD login failed.\"
-          echo \"WARN - If Steam Guard requested, enter code interactively at prompt.\"
-        fi
-        ATTEMPT=\$((ATTEMPT + 1))
-      done
-
-      if [ \"\$LOGIN_SUCCESS\" = false ]; then
-        echo \"ERROR - SteamCMD login failed after \$MAX_ATTEMPTS attempts - exiting.\"
+      echo \"INFO - SteamCMD login...\"
+      if timeout \${STEAMGUARD_TIMEOUT} steamcmd +login \"$STEAM_USERNAME\" \"$STEAM_PASSWORD\" +quit; then
+        echo \"INFO - SteamCMD authentication successful - proceeding with install/update of game server...\"
+        exit 0
+      else
+        echo \"ERROR - SteamCMD authentication failed or timed out - exiting...\"
         exit 2
       fi
     "
 
     if [ $? -ne 0 ]; then
-      error "SteamCMD login (as starbound) failed or exited with error."
+      error "SteamCMD authentication (as 'starbound' user) failed - exiting..."
       exit 2
     fi
 
   else
-    info "Steam Guard authentication is disabled - skipping..."
+    info "Environment variable 'USE_STEAMGUARD' is set to 'false' - skipping..."
   fi
 }

--- a/scripts/default/common
+++ b/scripts/default/common
@@ -141,7 +141,7 @@ steamGuardAuth() {
     su starbound -c "
       export HOME=/home/starbound
       ATTEMPT=1
-      MAX_ATTEMPTS=\${STEAMGUARD_MAX_RETRIES:-3}
+      MAX_ATTEMPTS=\${STEAMGUARD_MAX_ATTEMPTS:-3}
       LOGIN_SUCCESS=false
 
       # Loop to attempt SteamCMD login while Steam Guard is enabled

--- a/scripts/default/common
+++ b/scripts/default/common
@@ -118,8 +118,8 @@ checkRunning() {
 }
 
 steamGuardAuth() {
-  if [ "$USE_STEAMGUARD" == "true" ]; then
-    info "Environment variable 'USE_STEAMGUARD' is set to 'true' - beginning interactive SteamCMD login..."
+  if [ "$STEAMGUARD_REQUIRED" == "true" ]; then
+    info "Environment variable 'STEAMGUARD_REQUIRED' is set to 'true' - beginning interactive SteamCMD login..."
 
     if [ ! -t 0 ]; then
       error "stdin is not interactive/TTY; cannot proceed with interactive Steam Guard login - returning..."
@@ -155,7 +155,7 @@ steamGuardAuth() {
     fi
 
   else
-    info "Environment variable 'USE_STEAMGUARD' is set to 'false' - skipping..."
+    info "Environment variable 'STEAMGUARD_REQUIRED' is set to 'false' - skipping..."
   fi
 
   return 0

--- a/scripts/default/common
+++ b/scripts/default/common
@@ -122,14 +122,14 @@ steamGuardAuth() {
     info "Environment variable 'USE_STEAMGUARD' is set to 'true' - beginning interactive SteamCMD login..."
 
     if [ ! -t 0 ]; then
-      error "stdin is not interactive/TTY; cannot proceed with interactive Steam Guard login - exiting..."
-      exit 1
+      error "stdin is not interactive/TTY; cannot proceed with interactive Steam Guard login - returning..."
+      return 42
     fi
 
     # Check if Steam credentials from Docker secrets are available
     if [ ! -f "/run/secrets/steam_username" ] || [ ! -f "/run/secrets/steam_password" ]; then
       error "Missing Docker secrets: 'steam_username' and/or 'steam_password'"
-      exit 1
+      return 42
     fi
     
     # Set environment variable values for SteamCMD authentication and Steam credentials using Docker secrets
@@ -145,16 +145,18 @@ steamGuardAuth() {
         exit 0
       else
         echo \"ERROR - SteamCMD authentication failed or timed out - exiting...\"
-        exit 2
+        exit 42
       fi
     "
 
     if [ $? -ne 0 ]; then
-      error "SteamCMD authentication (as 'starbound' user) failed - exiting..."
-      exit 2
+      error "SteamCMD authentication (as 'starbound' user) failed - returning..."
+      return 42
     fi
 
   else
     info "Environment variable 'USE_STEAMGUARD' is set to 'false' - skipping..."
   fi
+
+  return 0
 }

--- a/scripts/default/defaults
+++ b/scripts/default/defaults
@@ -5,7 +5,7 @@ PUID=${PUID:-4711}
 PGID=${PGID:-4711}
 
 # Steam Settings
-USE_STEAMGUARD=${USE_STEAMGUARD:-false} # defaults to false; set to "true" if Steam account has Steam Guard enabled
+STEAMGUARD_REQUIRED=${STEAMGUARD_REQUIRED:-false} # defaults to false; set to "true" if Steam account has Steam Guard enabled
 STEAMGUARD_TIMEOUT=${STEAMGUARD_TIMEOUT:-300} # defaults to "300" seconds (i.e. 5 minutes)
 GAME_BRANCH=${GAME_BRANCH:-public}
 STEAMCMD_ARGS=${STEAMCMD_ARGS:-"$GAME_BRANCH" validate}

--- a/scripts/default/defaults
+++ b/scripts/default/defaults
@@ -5,6 +5,8 @@ PUID=${PUID:-4711}
 PGID=${PGID:-4711}
 
 # Steam Settings
+USE_STEAMGUARD=${USE_STEAMGUARD:-false} # defaults to false; set to "true" if Steam account has Steam Guard enabled
+STEAMGUARD_MAX_ATTEMPTS=${STEAMGUARD_MAX_ATTEMPTS:-3} # defaults to 3 attempts at successful login with Steam Guard before terminating game server deployment
 GAME_BRANCH=${GAME_BRANCH:-public}
 STEAMCMD_ARGS=${STEAMCMD_ARGS:-"$GAME_BRANCH" validate}
 

--- a/scripts/default/defaults
+++ b/scripts/default/defaults
@@ -6,7 +6,7 @@ PGID=${PGID:-4711}
 
 # Steam Settings
 USE_STEAMGUARD=${USE_STEAMGUARD:-false} # defaults to false; set to "true" if Steam account has Steam Guard enabled
-STEAMGUARD_MAX_ATTEMPTS=${STEAMGUARD_MAX_ATTEMPTS:-3} # defaults to 3 attempts at successful login with Steam Guard before terminating game server deployment
+STEAMGUARD_TIMEOUT=${STEAMGUARD_TIMEOUT:-300} # defaults to "300" seconds (i.e. 5 minutes)
 GAME_BRANCH=${GAME_BRANCH:-public}
 STEAMCMD_ARGS=${STEAMCMD_ARGS:-"$GAME_BRANCH" validate}
 


### PR DESCRIPTION
Steam Guard authentication routine is now available via `STEAMGUARD_REQUIRED` environment variable.

When `STEAMGUARD_REQUIRED` is set to "true", the base "bootstrap" script will defer to a single-purpose function (`steamGuardAuth`) that switches to the 'starbound' user temporarily to instantiate the Steam authentication workflow - and facilitates a window of opportunity to enter a valid a Steam Guard code via an interactive shell. `STEAMGUARD_TIMEOUT` influences the length of time (in seconds) that the window of opportunity stays open before closing and terminating the deployment routine - along with stopping the container itself (regardless of the `restart` policy).

When `STEAMGUARD_REQUIRED` is set to "false", the base "bootstrap" script will simply transition to the Supervisor-bound workflow that for the remainder of the game-server deployment routine - as if the whole function/context for Steam Guard did not exist. 

This deployment workflow accommodates users with Steam Guard enabled on their Steam accounts while maintaining backward compatibility for those without it.